### PR TITLE
Fix maintainer handle [ci skip]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,4 +51,4 @@ extra:
     - koverholt
     - alimanfoo
     - martindurant
-    - apitrou
+    - pitrou


### PR DESCRIPTION
Guessing this was just a typo. Caught it in the log of the team update script. So figured I'd fix it real quick. Skipped CI to save resources. Hope that is ok.

cc @mrocklin @pitrou