### PR TITLE
Require distributed 1.21.0+

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - bokeh
     - cloudpickle >=0.2.1
     - dask-core {{ version }}
-    - distributed >=1.21.1
+    - distributed >=1.21.0
     - numpy
     - pandas >=0.19.0
     - partd >=0.3.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: "{{ version }}"
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:


### PR DESCRIPTION
Relaxes the `distributed` version requirement from `1.21.1+` to `1.21.0+` in line with how it is set in `setup.py`.

xref: https://github.com/conda-forge/dask-feedstock/pull/34#pullrequestreview-99862904