### PR TITLE
Require cytoolz

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - python
     - bokeh
     - cloudpickle >=0.2.1
+    - cytoolz >=0.7.3
     - dask-core {{ version }}
     - distributed >=1.21.0
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: "{{ version }}"
 
 build:
-  number: 1
+  number: 2
   noarch: python
 
 requirements:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/dask-feedstock/issues/30

Adds `cytoolz` as a required dependency. Technically only `toolz` is required. However this is a nice optional dependency that offers a speedup over `toolz` and is easy for us to provide.

xref: https://github.com/conda-forge/distributed-feedstock/pull/45 (similar PR for `distributed`)