### PR TITLE
Split packages into finer grained dependencies

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -6,9 +6,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- '2.7'

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-dask-green.svg)](https://anaconda.org/conda-forge/dask) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dask.svg)](https://anaconda.org/conda-forge/dask) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dask.svg)](https://anaconda.org/conda-forge/dask) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dask.svg)](https://anaconda.org/conda-forge/dask) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dask--array-green.svg)](https://anaconda.org/conda-forge/dask-array) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dask-array.svg)](https://anaconda.org/conda-forge/dask-array) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dask-array.svg)](https://anaconda.org/conda-forge/dask-array) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dask-array.svg)](https://anaconda.org/conda-forge/dask-array) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dask--bag-green.svg)](https://anaconda.org/conda-forge/dask-bag) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dask-bag.svg)](https://anaconda.org/conda-forge/dask-bag) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dask-bag.svg)](https://anaconda.org/conda-forge/dask-bag) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dask-bag.svg)](https://anaconda.org/conda-forge/dask-bag) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dask--dataframe-green.svg)](https://anaconda.org/conda-forge/dask-dataframe) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dask-dataframe.svg)](https://anaconda.org/conda-forge/dask-dataframe) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dask-dataframe.svg)](https://anaconda.org/conda-forge/dask-dataframe) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dask-dataframe.svg)](https://anaconda.org/conda-forge/dask-dataframe) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dask--delayed-green.svg)](https://anaconda.org/conda-forge/dask-delayed) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dask-delayed.svg)](https://anaconda.org/conda-forge/dask-delayed) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dask-delayed.svg)](https://anaconda.org/conda-forge/dask-delayed) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dask-delayed.svg)](https://anaconda.org/conda-forge/dask-delayed) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-dask--distributed-green.svg)](https://anaconda.org/conda-forge/dask-distributed) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/dask-distributed.svg)](https://anaconda.org/conda-forge/dask-distributed) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/dask-distributed.svg)](https://anaconda.org/conda-forge/dask-distributed) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dask-distributed.svg)](https://anaconda.org/conda-forge/dask-distributed) |
 
 Installing dask
 ===============
@@ -33,10 +38,10 @@ Installing `dask` from the `conda-forge` channel can be achieved by adding `cond
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `dask` can be installed with:
+Once the `conda-forge` channel has been enabled, `dask, dask-array, dask-bag, dask-dataframe, dask-delayed, dask-distributed` can be installed with:
 
 ```
-conda install dask
+conda install dask dask-array dask-bag dask-dataframe dask-delayed dask-distributed
 ```
 
 It is possible to list all of the versions of `dask` available on your platform with:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,40 +2,87 @@
 
 package:
   name: dask
-  version: "{{ version }}"
+  version: {{ version }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:
-  build:
-    - python
-
   run:
-    - python
     - bokeh >=0.13.0
-    - cloudpickle >=0.2.1
-    - cytoolz >=0.7.3
-    - dask-core {{ version }}
-    - distributed >=1.23.3
-    - numpy >=1.11.0
-    - pandas >=0.19.0
-    - partd >=0.3.8
-    - toolz >=0.7.3
+    - dask-core  =={{ version }}
+    - {{ pin_subpackage('dask-array', exact=True) }}
+    - {{ pin_subpackage('dask-bag', exact=True) }}
+    - {{ pin_subpackage('dask-dataframe', exact=True) }}
+    - {{ pin_subpackage('dask-distributed', exact=True) }}
+    - {{ pin_subpackage('dask-delayed', exact=True) }}
 
-test:
-  imports:
-    - dask
-    - dask.array
-    - dask.bag
-    - dask.bytes
-    - dask.dataframe
-    - dask.dataframe.tseries
-    - dask.delayed
-    - dask.diagnostics
-    - dask.distributed
-    - distributed
+outputs:
+  - name: dask-array
+    build:
+      noarch: python
+    requirements:
+      run:
+        - dask-core  =={{ version }}
+        - numpy >=1.11.0
+        - toolz >=0.7.3
+        - cytoolz >=0.7.3
+    test:
+      imports:
+        - dask.array
+  - name: dask-bag
+    build:
+      noarch: python
+    requirements:
+      run:
+        - dask-core  =={{ version }}
+        - cloudpickle >=0.2.1
+        - toolz >=0.7.3
+        - cytoolz >=0.7.3
+        - partd >=0.3.8
+    test:
+      imports:
+        - dask.bag
+        - dask.bytes
+  - name: dask-dataframe
+    build:
+      noarch: python
+    requirements:
+      run:
+        - dask-core  =={{ version }}
+        - numpy >=1.11.0
+        - pandas >=0.19.0
+        - toolz >=0.7.3
+        - cytoolz >=0.7.3
+        - partd >=0.3.8
+        - cloudpickle >=0.2.1
+    test:
+      imports:
+        - dask.dataframe
+        - dask.dataframe.tseries
+  - name: dask-distributed
+    build:
+      noarch: python
+    requirements:
+      run:
+        - dask-core  =={{ version }}
+        - distributed >=1.23.3
+    test:
+      imports:
+        - dask.distributed
+        - distributed
+  - name: dask-delayed
+    build:
+      noarch: python
+    requirements:
+      run:
+        - dask-core  =={{ version }}
+        - toolz >=0.7.3
+        - cytoolz >=0.7.3
+    test:
+      imports:
+        - dask.delayed
 
 about:
   home: http://github.com/dask/dask/


### PR DESCRIPTION
Well it just took me 30 mins to rebuild my scientific environment after downloading :/ on windows.
I think the big dependencies are: opencv, xarray, pyqt, dask
pyqt and opencv are probably the big offenders, but dask (pure python) is an easy target.

Comments are appreciated 

From https://github.com/conda-forge/dask-feedstock/issues/46 it seems like this is something that people generally want.


Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.