### PR TITLE
Bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e76088e8931b326c05a92d2658e07b94a6852b42c13a7560505a8b2354871454
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 requirements:


### PR DESCRIPTION
Seems like the post-merge build on master was not triggered after #59 was merged.

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

Closes #60 