### PR TITLE
Request bot to check solvable before opening PRs

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,2 @@
 conda_forge_output_validation: true
+bot: {check_solvable: true}


### PR DESCRIPTION
As `dask` package builds depend on `dask-core` and `distributed` package builds, if PRs are opened to both feedstocks to update the package version at the same time, the PR to `dask` will fail until `dask-core` and `distributed` packages are available. This fixes that issue by ensuring that `dask`'s dependencies (`dask-core` and `distributed` in this case) are available before opening a PR. That way the PR will only be opened after `dask-core` and `distributed` has new packages published. Should cutdown the time recipe maintainers spend restarting CI to get the new dependencies.

cc @CJ-Wright @jrbourbeau

<hr>

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
