### PR TITLE
Fix `dask-core` / `distributed` pinning to properly exclude nightlies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,12 @@ build:
 requirements:
   host:
     - python >=3.8
+    - dask-core {{ version }}
+    - distributed {{ version }}
   run:
     - python >=3.8
-    - dask-core {{ version }}.*,!={{ version }}a.*
-    - distributed {{ version }}.*,!={{ version }}a.*
+    - {{ pin_compatible('dask-core', max_pin='x.x.x') }}
+    - {{ pin_compatible('distributed', max_pin='x.x.x') }}
     - cytoolz >=0.8.2
     - lz4
     - numpy >=1.18

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a14c1c5143081701d4fe62283e09cc5ad5336dff3a152de64eb77ee3180e9792
 
 build:
-  number: 1
+  number: 2
   noarch: python
 
 requirements:
@@ -18,8 +18,8 @@ requirements:
     - python >=3.8
   run:
     - python >=3.8
-    - dask-core ={{ version }},!={{ version }}a*
-    - distributed ={{ version }},!={{ version }}a*
+    - dask-core {{ version }}.*,!={{ version }}a.*
+    - distributed {{ version }}.*,!={{ version }}a.*
     - cytoolz >=0.8.2
     - lz4
     - numpy >=1.18


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

As brought up in https://github.com/conda-forge/dask-feedstock/pull/190#issuecomment-1215624680, the pinning introduced in #190 accidentally blocked the security backport proposal - tested this new pinning out locally and it seems to work with backports while also blocking nightly packages.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
