### PR TITLE
Switch from `pin_compatible` to explicit exclusion of nightly versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,18 +10,16 @@ source:
   sha256: 84f9f229e4fc6c0df8a23620f2b03f277b1bfb15a497603c704743443e38d420
 
 build:
-  number: 2
+  number: 3
   noarch: python
 
 requirements:
   host:
     - python >=3.8
-    - dask-core {{ version }}
-    - distributed {{ version }}
   run:
     - python >=3.8
-    - {{ pin_compatible('dask-core', max_pin='x.x.x') }}
-    - {{ pin_compatible('distributed', max_pin='x.x.x') }}
+    - dask-core {{ version }}.*,!={{ version }}a.*
+    - distributed {{ version }}.*,!={{ version }}a.*
     - cytoolz >=0.8.2
     - lz4
     - numpy >=1.18


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Turns out we need a tighter pinning than what (from my understanding) `pin_compatible` is able to generate - for example, generated pinning `>=2022.8.1,<2022.8.2.0a0` would allow us to install dask 2022.8.1 with 2022.8.2a packages.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
