### PR TITLE
Rely on `dask-core` version constraints

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,12 +23,12 @@ requirements:
     - {{ pin_compatible('dask-core', max_pin='x.x.x') }}
     - {{ pin_compatible('distributed', max_pin='x.x.x') }}
     - cytoolz >=0.11.0
-    - lz4 >=4.3.2
-    - numpy >=1.21
-    - pandas >=1.3
-    - bokeh >=2.4.2,!=3.0.*
-    - jinja2 >=2.10.3
-    - pyarrow >=7.0
+    - numpy
+    - pandas
+    - bokeh !=3.0.*
+    - jinja2
+    - pyarrow
+    - lz4
 
   run_constrained:
     - openssl !=1.1.1e


### PR DESCRIPTION
Builds on PR ( https://github.com/conda-forge/dask-core-feedstock/pull/171 ) to rely on `dask-core` to have the right version constraints applied to these. That way the dependencies can just be listed here (without needing to worry about versions)

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
